### PR TITLE
:sparkles: new: selection serialization between sessions

### DIFF
--- a/src/ui/components/UITable.cpp
+++ b/src/ui/components/UITable.cpp
@@ -18,8 +18,6 @@
 
 #include "ui/components/UIModule.h"
 
-// TODO: Serialize table selection in state
-
 namespace Modex
 {
 	bool UITable::IsValidTargetReference(RE::TESObjectREFR* a_reference) {
@@ -183,6 +181,14 @@ namespace Modex
 		UserData::Set<bool>(data_id + "::ShowFormID", showFormID);
 		UserData::Set<std::string>(data_id + "::LastSelectedPlugin", selectedPlugin);
 		UserData::Set<uint32_t>(data_id + "::TableMode", tableMode);
+
+		std::vector<uint32_t> selectedFormIDs;
+		for (auto& item : tableList) {
+			if (selectionStorage.Contains(item->m_tableID)) {
+				selectedFormIDs.push_back(item->GetBaseFormID());
+			}
+		}
+		UserData::Set<std::vector<uint32_t>>(data_id + "::Selection", selectedFormIDs);
 	}
 
 	void UITable::LoadSystemState()
@@ -190,6 +196,9 @@ namespace Modex
 		filterSystem->LoadState(data_id + "::FilterState");
 		sortSystem->LoadState(data_id + "::SortState");
 		searchSystem->LoadState(data_id + "::SearchState");
+
+		auto savedSelection = UserData::Get<std::vector<uint32_t>>(data_id + "::Selection");
+		m_pendingSelection.insert(savedSelection.begin(), savedSelection.end());
 	}
 
 	void UITable::CleanupResources()
@@ -781,6 +790,14 @@ namespace Modex
 			tableList[i]->m_tableID = i;
 		}
 
+		if (!m_pendingSelection.empty()) {
+			for (auto& item : tableList) {
+				if (m_pendingSelection.contains(item->GetBaseFormID())) {
+					selectionStorage.SetItemSelected(item->m_tableID, true);
+				}
+			}
+			m_pendingSelection.clear();
+		}
 	}
 
 	std::vector<BaseObject> UITable::GetReferenceInventory()

--- a/src/ui/components/UITable.h
+++ b/src/ui/components/UITable.h
@@ -88,6 +88,7 @@ namespace Modex
 		ImVec2                  ItemSize;
 
 		ImGuiID                 navPositionID = 0;
+		std::unordered_set<RE::FormID> m_pendingSelection;
 
 		inline static bool test_selection = false;
 		inline static bool test_filters = false;


### PR DESCRIPTION
**State persistence and restoration:**

* Selection state is now serialized: the form IDs of selected items are saved to user data when the table state is stored.
* On loading the system state, previously saved selection is retrieved and stored in the new member variable `m_pendingSelection`. [[1]](diffhunk://#diff-298184eb76a606558bab76afbb435bcbb9c2e3f08908257c8214923474d06408R184-R201) [[2]](diffhunk://#diff-b05ecddb6c90244d840c2461003287a9bf5e3bf4dcd3e507a5ae9758440e2f68R91)
* After table items are initialized, any pending selections are applied by matching form IDs and updating the selection storage, then clearing the pending selection.

**New member variable:**

* Added `m_pendingSelection` (`std::unordered_set<RE::FormID>`) to `UITable` for temporarily storing selection state during reload.