### PR TITLE
:bug: fix: refactor and squash bug with show results in-game

### DIFF
--- a/dist/Interface/Modex/language/english.json
+++ b/dist/Interface/Modex/language/english.json
@@ -216,6 +216,7 @@
 "_CONTAINER_VIEW": "======== Container View Actions ========",
 "CONTAINER_VIEW": "Show Results In-game",
 "CONTAINER_VIEW_TOOLTIP": "Show Results\n\nView the contents of your search in an in-game container. There you can preview, or loot items directly in-game",
+"CONTAINER_VIEW_HIDDEN_TOOLTIP": "Hide Chest\n\nWhen enabled, the chest spawns hidden beneath you instead of being placed in front. The container menu still opens normally — useful when you only want the inventory without a visible chest in the world.",
 "CONTAINER_VIEW_KIT": "Show Kit In-game",
 "CONTAINER_VIEW_KIT_TOOLTIP": "Show Results\n\nView the contents of this Kit in an in-game container. Allowing you to preview, or loot items directly in-game.",
 "CONTAINER_VIEW_TARGET": "Open Target Inventory",

--- a/src/core/Hooks.cpp
+++ b/src/core/Hooks.cpp
@@ -1,5 +1,6 @@
 #include "core/Hooks.h"
 #include "core/InputManager.h"
+#include "core/PlayerChestSpawn.h"
 #include "ui/core/UIManager.h"
 #include "ui/core/UIMenuImpl.h"
 #include <memory>
@@ -12,6 +13,14 @@ namespace Hooks
 {
 	RE::BSEventNotifyControl IMenuOpenCloseEvent::ProcessEvent(const RE::MenuOpenCloseEvent* event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) {
 		if (!event->opening) {
+			if (event->menuName == Modex::ModexGUIMenu::MENU_NAME) {
+				Modex::PlayerChestSpawn::GetSingleton()->OnModexClosed();
+			}
+
+			if (event->menuName == RE::ContainerMenu::MENU_NAME) {
+				Modex::PlayerChestSpawn::GetSingleton()->OnContainerMenuClosed();
+			}
+
 			if (const auto& manager = Modex::UIManager::GetSingleton(); manager != nullptr) {
 				if (event->menuName == RE::ContainerMenu::MENU_NAME) {
 					if (manager->GetMenuListener()) {

--- a/src/core/PlayerChestSpawn.cpp
+++ b/src/core/PlayerChestSpawn.cpp
@@ -4,35 +4,30 @@
 #include "ui/core/UIManager.h"
 #include "core/Commands.h"
 
+#include <cmath>
+
 namespace Modex
 {
+	constexpr float kChestForwardDistance = 110.0f;
+	constexpr float kChestHiddenDepth = 1000.0f;
+
+	// NOTE: Should we expose the hidden depth in settings? O.o
+
 	void PlayerChestSpawn::InitializeBaseContainer()
 	{
-		auto* handler = RE::TESDataHandler::GetSingleton();
-
-		if (!handler) {
-			Error("Failed to get TESDataHandler for PlayerChest init");
-			return;
-		}
-
-		// Lookup valid container base form, instead of creating one (caused save corruption)
-		auto& containers = handler->GetFormArray<RE::TESObjectCONT>();
-		for (auto* form : containers) {
-			if (form && (form->GetFormID() >> 24) < 0xFF) {
-				m_chestContainer = form;
-				break;
-			}
-		}
+		// chest container from skyrim.esm just to be safe, hopefully.
+		auto* form = RE::TESForm::LookupByID(RE::FormID(0x000D762F));
+		m_chestContainer = form ? form->As<RE::TESObjectCONT>() : nullptr;
 
 		if (!m_chestContainer) {
-			Error("Failed to find a valid container base form");
+			Error("Failed to lookup vanilla chest base form [0x000D762F]");
 			return;
 		}
 
 		Trace("Modex PlayerChest using base container [{:08X}]", m_chestContainer->GetFormID());
 	}
 
-	RE::TESObjectREFR* PlayerChestSpawn::SpawnChestReference()
+	RE::TESObjectREFR* PlayerChestSpawn::SpawnChestReference(Placement a_placement)
 	{
 		if (!m_chestContainer) {
 			InitializeBaseContainer();
@@ -46,16 +41,15 @@ namespace Modex
 		if (!player)
 			return nullptr;
 
-		auto playerRef = player->AsReference();
+		auto* playerRef = player->AsReference();
 
 		if (!playerRef)
 			return nullptr;
 
-		DestroyChestReference();
+		m_chestRefHandle.reset();
 
-		// Place a fresh container reference in the world near the player.
-		// This goes through the engine's full placement pipeline, ensuring
-		// proper cell membership, ExtraContainerChanges, and extra data init.
+		// Tried to use create reference, but I think this is safer.
+		// Do not flag as persistent for our use, potentially reason for save corruption
 		auto* chestRef = Commands::Papyrus_PlaceAtMe(playerRef, m_chestContainer, 1, false, false);
 
 		if (!chestRef) {
@@ -63,30 +57,88 @@ namespace Modex
 			return nullptr;
 		}
 
-		chestRef->formFlags |= RE::TESForm::RecordFlags::kTemporary;
+		// Best guess at positioning the chest
+		auto playerPos = player->GetPosition();
+		float heading = player->GetAngle().z;
 
-		if (auto* playerRef = player->GetObjectReference()) {
-			chestRef->extraList.SetOwner(playerRef);
+		RE::NiPoint3 spawnPos = playerPos;
+		switch (a_placement) {
+		case Placement::HiddenBelowPlayer:
+			spawnPos.z -= kChestHiddenDepth;
+			break;
+		case Placement::InFrontOfPlayer:
+		default:
+			spawnPos.x += std::sin(heading) * kChestForwardDistance;
+			spawnPos.y += std::cos(heading) * kChestForwardDistance;
+			break;
 		}
 
-		chestRef->InitInventoryIfRequired(true);
+		RE::NiPoint3 uprightAngle = { 0.0f, 0.0f, heading };
+
+		chestRef->SetPosition(spawnPos);
+		chestRef->SetAngle(uprightAngle);
+		chestRef->Update3DPosition(true);
+
+		// assign ownership to circumvent stolen flag in interiors
+		if (auto* playerBase = player->GetObjectReference()) {
+			chestRef->extraList.SetOwner(playerBase);
+		}
+
+		// flag OnContainerMenuClosed so hidden chests don't accumulate.
+		m_cleanupOnClose = (a_placement == Placement::HiddenBelowPlayer);
 
 		m_chestRefHandle = chestRef->GetHandle();
 		Debug("Spawned new PlayerChest reference [{:08X}]", chestRef->GetFormID());
 		return chestRef;
 	}
 
-	void PlayerChestSpawn::DestroyChestReference()
+	void PlayerChestSpawn::QueueOrDispatch(std::function<void()> a_action)
 	{
-		auto* chestRef = m_chestRefHandle.get().get();
-		m_chestRefHandle.reset();
+		auto* ui = UIManager::GetSingleton();
 
-		if (!chestRef)
+		if (ui->IsMenuOpen()) {
+			{
+				std::lock_guard<std::mutex> lock(m_pendingMutex);
+				m_pendingAction = std::move(a_action);
+			}
+			ui->Close();
+			ui->SetMenuListener(true);
+		} else {
+			SKSE::GetTaskInterface()->AddTask(std::move(a_action));
+		}
+	}
+
+	void PlayerChestSpawn::OnContainerMenuClosed()
+	{
+		if (!m_cleanupOnClose) return;
+
+		m_cleanupOnClose = false;
+
+		// Be safe and do all this on game thread, not UI thread
+		SKSE::GetTaskInterface()->AddTask([this]() {
+			auto* chestRef = m_chestRefHandle.get().get();
+			if (!chestRef) return;
+
+			chestRef->Disable();
+			chestRef->SetDelete(true);
+			m_chestRefHandle.reset();
+			Debug("Discarded hidden PlayerChest");
+		});
+	}
+
+	void PlayerChestSpawn::OnModexClosed()
+	{
+		std::function<void()> action;
+		{
+			std::lock_guard<std::mutex> lock(m_pendingMutex);
+			action = std::move(m_pendingAction);
+			m_pendingAction = nullptr;
+		}
+
+		if (!action)
 			return;
 
-		chestRef->Disable();
-		chestRef->SetDelete(true);
-		Debug("Destroyed PlayerChest reference [{:08X}]", chestRef->GetFormID());
+		SKSE::GetTaskInterface()->AddTask(std::move(action));
 	}
 
 	void PlayerChestSpawn::OpenChest()
@@ -108,18 +160,21 @@ namespace Modex
 		if (!playerRef)
 			return;
 
-		UIManager::GetSingleton()->Close();
+		if (UIManager::GetSingleton()->IsMenuOpen()) {
+			UIManager::GetSingleton()->Close();
+			UIManager::GetSingleton()->SetMenuListener(true);
+		}
+
 		chestRef->ActivateRef(playerRef, 0, nullptr, 0, false);
-		UIManager::GetSingleton()->SetMenuListener(true);
 		Debug("Opened PlayerChest container");
 	}
 
-	void PlayerChestSpawn::PopulateChestWithOutfit(const RE::BGSOutfit* a_outfit, uint16_t a_level)
+	void PlayerChestSpawn::PopulateChestWithOutfit(const RE::BGSOutfit* a_outfit, uint16_t a_level, Placement a_placement)
 	{
 		if (!a_outfit) return;
 
-		SKSE::GetTaskInterface()->AddTask([this, a_outfit, a_level]() {
-			auto container = SpawnChestReference();
+		QueueOrDispatch([this, a_outfit, a_level, a_placement]() {
+			auto container = SpawnChestReference(a_placement);
 
 			if (!container)
 				return;
@@ -127,32 +182,25 @@ namespace Modex
 			auto displayName = po3_GetEditorID(a_outfit->GetFormID());
 			container->SetDisplayName(displayName.c_str(), true);
 
-			auto resolved = Commands::ResolveOutfitItems(a_outfit, Commands::GetPlayerReference(), a_level);
+			auto* playerRef = Commands::GetPlayerReference();
+			auto resolved = Commands::ResolveOutfitItems(a_outfit, playerRef, a_level);
 
 			for (auto& entry : resolved) {
-				container->AddObjectToContainer(
-					entry.object,
-					nullptr,
-					entry.count,
-					nullptr
-				);
+				container->AddObjectToContainer(entry.object, nullptr, entry.count, nullptr);
 			}
 
-			SKSE::GetTaskInterface()->AddTask([this]() {
-				OpenChest();
-			});
+			SKSE::GetTaskInterface()->AddTask([this]() { OpenChest(); });
 		});
 	}
 
-	void PlayerChestSpawn::PopulateChestWithKit(const Modex::Kit& a_kit)
+	void PlayerChestSpawn::PopulateChestWithKit(const Modex::Kit& a_kit, Placement a_placement)
 	{
 		auto kitName = a_kit.GetName();
 		auto kitKey = a_kit.m_key;
 		auto kitItems = a_kit.m_items;
-		auto kitSize = a_kit.m_items.size();
 
-		SKSE::GetTaskInterface()->AddTask([this, kitName, kitKey, kitItems, kitSize]() {
-			auto container = SpawnChestReference();
+		QueueOrDispatch([this, kitName, kitKey, kitItems, a_placement]() {
+			auto container = SpawnChestReference(a_placement);
 
 			if (!container)
 				return;
@@ -170,23 +218,54 @@ namespace Modex
 							bound,
 							nullptr,
 							static_cast<std::uint32_t>(kitItem->m_amount),
-							nullptr
-						);
+							nullptr);
 
 						_count++;
 					}
 				}
 			}
 
-			Debug("Populated PlayerChest with '{}/{}' items from kit: '{}'", _count, kitSize, kitKey);
+			Debug("Populated PlayerChest with '{}/{}' items from kit: '{}'", _count, kitItems.size(), kitKey);
 
-			SKSE::GetTaskInterface()->AddTask([this]() {
-				OpenChest();
-			});
+			SKSE::GetTaskInterface()->AddTask([this]() { OpenChest(); });
 		});
 	}
 
-	void PlayerChestSpawn::PopulateChestWithItems(const std::vector<std::unique_ptr<BaseObject>>& a_items)
+	void PlayerChestSpawn::PopulateChestWithActorInventory(RE::TESObjectREFR* a_actor, Placement a_placement)
+	{
+		if (!a_actor) return;
+
+		// Capture by handle in case reference dies between calls
+		auto actorHandle = a_actor->GetHandle();
+
+		QueueOrDispatch([this, actorHandle, a_placement]() {
+			auto* actor = actorHandle.get().get();
+			if (!actor) return;
+
+			auto container = SpawnChestReference(a_placement);
+			if (!container) return;
+
+			container->SetDisplayName(actor->GetDisplayFullName(), true);
+
+			auto inventory = actor->GetInventory();
+
+			int _count = 0;
+			for (auto& [bound, data] : inventory) {
+				const auto count = data.first;
+				if (bound && count > 0) {
+					container->AddObjectToContainer(bound, nullptr, count, nullptr);
+					_count++;
+				}
+			}
+
+			Debug("Populated PlayerChest with '{}' unique items from actor: '{}'",
+				_count, actor->GetDisplayFullName());
+
+			SKSE::GetTaskInterface()->AddTask([this]() { OpenChest(); });
+		});
+	}
+
+	void PlayerChestSpawn::PopulateChestWithItems(const std::vector<std::unique_ptr<BaseObject>>& a_items, Placement a_placement)
 	{
 		if (a_items.empty()) { return; }
 
@@ -196,9 +275,8 @@ namespace Modex
 			editorIDs.push_back(item->GetEditorID());
 		}
 
-		// Frame 1: Spawn fresh container and populate it.
-		SKSE::GetTaskInterface()->AddTask([this, items = std::move(editorIDs)]() {
-			auto container = SpawnChestReference();
+		QueueOrDispatch([this, items = std::move(editorIDs), a_placement]() {
+			auto container = SpawnChestReference(a_placement);
 
 			if (!container)
 				return;
@@ -212,13 +290,7 @@ namespace Modex
 
 				if (boundObject) {
 					if (auto bound = boundObject->As<RE::TESBoundObject>()) {
-						container->AddObjectToContainer(
-							bound,
-							nullptr,
-							1,
-							nullptr
-						);
-
+						container->AddObjectToContainer(bound, nullptr, 1, nullptr);
 						_count++;
 					}
 				}
@@ -226,10 +298,7 @@ namespace Modex
 
 			Debug("Populated PlayerChest with '{}/{}' items from Table.", _count, items.size());
 
-			// Frame 2: Open after engine processes inventory.
-			SKSE::GetTaskInterface()->AddTask([this]() {
-				OpenChest();
-			});
+			SKSE::GetTaskInterface()->AddTask([this]() { OpenChest(); });
 		});
 	}
 }

--- a/src/core/PlayerChestSpawn.h
+++ b/src/core/PlayerChestSpawn.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <mutex>
+
 #include "data/BaseObject.h"
 
 namespace Modex
@@ -7,24 +10,37 @@ namespace Modex
 	class PlayerChestSpawn
 	{
 	public:
+		enum class Placement
+		{
+			InFrontOfPlayer,
+			HiddenBelowPlayer,
+		};
+
 		static inline PlayerChestSpawn* GetSingleton()
 		{
 			static PlayerChestSpawn singleton;
 			return std::addressof(singleton);
 		}
 
-		void PopulateChestWithItems(const std::vector<std::unique_ptr<BaseObject>>& a_items);
-		void PopulateChestWithKit(const Modex::Kit& a_kit);
-		void PopulateChestWithOutfit(const RE::BGSOutfit* a_outfit, uint16_t a_level = 0);
+		void PopulateChestWithItems(const std::vector<std::unique_ptr<BaseObject>>& a_items, Placement a_placement = Placement::InFrontOfPlayer);
+		void PopulateChestWithKit(const Modex::Kit& a_kit, Placement a_placement = Placement::InFrontOfPlayer);
+		void PopulateChestWithOutfit(const RE::BGSOutfit* a_outfit, uint16_t a_level = 0, Placement a_placement = Placement::InFrontOfPlayer);
+		void PopulateChestWithActorInventory(RE::TESObjectREFR* a_actor, Placement a_placement = Placement::HiddenBelowPlayer);
 		void OpenChest();
-		void DestroyChestReference();
+
+		void OnModexClosed();
+		void OnContainerMenuClosed();
 
 	private:
 		void InitializeBaseContainer();
-		RE::TESObjectREFR* SpawnChestReference();
+		RE::TESObjectREFR* SpawnChestReference(Placement a_placement);
+		void QueueOrDispatch(std::function<void()> a_action);
 
 	private:
 		RE::TESObjectCONT*      m_chestContainer = nullptr;
 		RE::ObjectRefHandle     m_chestRefHandle;
+		std::function<void()>   m_pendingAction;
+		std::mutex              m_pendingMutex;
+		bool                    m_cleanupOnClose = false;
 	};
 }

--- a/src/ui/components/UIContainers.cpp
+++ b/src/ui/components/UIContainers.cpp
@@ -73,11 +73,49 @@ namespace Modex
 				Commands::OpenActorInventory(a_view->GetTableTargetRef());
 			}
 
-			if (UICustom::ActionButton("CONTAINER_VIEW", ImVec2(max_width, button_height), !Commands::IsGameMenuOpen())) {
-				bool max_query = std::ssize(a_view->GetTableList()) >= UserConfig::Get().maxQuery;
-				UIManager::GetSingleton()->ShowWarning(Translate("WARNING"), Translate("ERROR_MAX_QUERY"), max_query, [&a_view]() {
-					PlayerChestSpawn::GetSingleton()->PopulateChestWithItems(a_view->GetTableList());
-				});
+			{
+				const float padding_x = ImGui::GetStyle().FramePadding.x;
+				const float padding_y = (button_height - ImGui::GetFontSize()) * 0.5f;
+				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(padding_x, padding_y));
+
+				const float checkbox_w = ImGui::GetFrameHeight();
+				const float container_view_w = max_width - checkbox_w;
+
+				bool hideChest = UserData::Get<bool>("ShowResults.HideChest", true);
+
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ThemeConfig::GetColor("BG_LIGHT"));
+				ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ThemeConfig::GetHover("BG_LIGHT"));
+				ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ThemeConfig::GetActive("BG_LIGHT"));
+				ImGui::PushStyleColor(ImGuiCol_CheckMark, ThemeConfig::GetColor("PRIMARY"));
+				if (ImGui::Checkbox("##CONTAINER_VIEW_HIDDEN", &hideChest)) {
+					UserData::Set<bool>("ShowResults.HideChest", hideChest);
+				}
+				ImGui::PopStyleColor(4);
+				ImGui::PopStyleVar();
+
+				if (ImGui::IsItemHovered()) {
+					UICustom::FancyTooltip("CONTAINER_VIEW_HIDDEN_TOOLTIP");
+				}
+
+				ImGui::SameLine(0.0f, 0.0f);
+
+				const ImVec2 text_size = ImGui::CalcTextSize(Translate("CONTAINER_VIEW"));
+				const float free_space = container_view_w - text_size.x;
+				const float align_x = free_space > 0.0f
+					? ((max_width - text_size.x) * 0.5f - checkbox_w) / free_space
+					: 0.5f;
+
+				ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(align_x, 0.5f));
+				if (UICustom::ActionButton("CONTAINER_VIEW", ImVec2(container_view_w, button_height), !Commands::IsGameMenuOpen())) {
+					bool max_query = std::ssize(a_view->GetTableList()) >= UserConfig::Get().maxQuery;
+					UIManager::GetSingleton()->ShowWarning(Translate("WARNING"), Translate("ERROR_MAX_QUERY"), max_query, [&a_view, hideChest]() {
+						const auto placement = hideChest
+							? PlayerChestSpawn::Placement::HiddenBelowPlayer
+							: PlayerChestSpawn::Placement::InFrontOfPlayer;
+						PlayerChestSpawn::GetSingleton()->PopulateChestWithItems(a_view->GetTableList(), placement);
+					});
+				}
+				ImGui::PopStyleVar();
 			}
 			ImGui::PopStyleColor(3);
 
@@ -146,10 +184,10 @@ namespace Modex
 			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ThemeConfig::GetHover("SECONDARY"));
 			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ThemeConfig::GetActive("SECONDARY"));
 			if (UICustom::ActionButton("CONTAINER_VIEW_TARGET", ImVec2(max_width, button_height), valid_table_target)) {
-				Commands::OpenActorInventory(a_view->GetTableTargetRef());
+				PlayerChestSpawn::GetSingleton()->PopulateChestWithActorInventory(a_view->GetTableTargetRef());
 			}
 			if (UICustom::ActionButton("CONTAINER_VIEW_SELECTION", ImVec2(max_width, button_height), valid_selection_target)) {
-				Commands::OpenActorInventory(a_view->GetSelectedReference());
+				PlayerChestSpawn::GetSingleton()->PopulateChestWithActorInventory(a_view->GetSelectedReference());
 			}
 			ImGui::PopStyleColor(3);
 


### PR DESCRIPTION
Believe it had something to do with the commit 8be4371 related to the fromRef arg on AddObjectToContainer which caused issues with autosave on cell changes.

Added/Expanded the show results in-game to optionally place a chest. It now always places a chest, but discards it if the hidden flag is set. Maybe more reliable then dynamic lookup and placement of a container form